### PR TITLE
Update teacher server to use IV2 6B embeddings

### DIFF
--- a/InternVideo2/multi_modality/teacher_distill_server/README.md
+++ b/InternVideo2/multi_modality/teacher_distill_server/README.md
@@ -1,0 +1,20 @@
+# InternVideo2 6B Embeddings Server
+
+In order to start the server, first run:
+
+```
+$ huggingface-cli download OpenGVLab/InternVideo2-Stage2_6B-224p-f4 internvideo2-s2_6b-224p-f4.pt --local-dir .
+[It will show the path to the file]
+```
+
+Then run:
+
+```
+$ export IV2_6B_CKPT=/path/to/internvideo2-s2_6b-224p-f4.pt
+```
+
+And then
+
+```
+$ python3 server.py
+```


### PR DESCRIPTION
## Summary
- remove unused text support from the teacher distill server
- wire the server to InternVideo2 6B model for real embeddings
- adapt API so gather_embeddings.py can consume it

## Testing
- `python -m py_compile InternVideo2/multi_modality/teacher_distill_server/server.py`
