### PR TITLE
Add server testing instructions

### DIFF
--- a/InternVideo2/multi_modality/teacher_distill_server/README.md
+++ b/InternVideo2/multi_modality/teacher_distill_server/README.md
@@ -18,3 +18,20 @@ And then
 ```
 $ python3 server.py
 ```
+
+## Testing the server
+
+The script starts a FastAPI service bound to `0.0.0.0:8008`. To query the
+service from another machine, replace `<server-ip>` with the address of the
+server and send requests to `http://<server-ip>:8008/infer`.
+
+Example request:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"window_tensor":[[[[0]]]]}' \
+     http://<server-ip>:8008/infer
+```
+
+If the command fails or times out, verify that the server is running and that
+firewall rules allow access to port `8008`.


### PR DESCRIPTION
## Summary
- document how to test the InternVideo2 embedding server

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a063c75b0832fb0ba53e5893a1476