### PR TITLE
Add vision-only mode for embedding script

### DIFF
--- a/InternVideo2/multi_modality/tasks_clip/gather_embeddings.py
+++ b/InternVideo2/multi_modality/tasks_clip/gather_embeddings.py
@@ -91,7 +91,7 @@ def _load_model():
 
     logger.info(f"Final config for InternVideo2 Stage2 6b: {CFG.model}")
 
-    MODEL, _ = setup_internvideo2(CFG)
+    MODEL, _ = setup_internvideo2(CFG, no_text=True)
     MODEL.eval()
     return MODEL
 


### PR DESCRIPTION
## Summary
- add `InternVideo2_Stage2_VisionOnly` class without the text encoder
- allow `setup_internvideo2` to create this vision-only model and drop text weights when loading checkpoints
- update gather_embeddings to request the vision-only model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683b47900520832f9de700b702145d68