### PR TITLE
Enable precise resuming for pretraining

### DIFF
--- a/InternVideo2/multi_modality/dataset/dataloader.py
+++ b/InternVideo2/multi_modality/dataset/dataloader.py
@@ -57,8 +57,8 @@ class MetaLoader(object):
 
 
 class MetaLoader_rs(object):
-    """ wraps multiple data loader """
-    def __init__(self, name2loader, skip_num=0):
+    """Wraps multiple data loaders with optional deterministic ordering."""
+    def __init__(self, name2loader, skip_num=0, seed=None):
         """Iterates over multiple dataloaders, it ensures all processes
         work on data from the same dataloader. This loader will end when
         the shorter dataloader raises StopIteration exception.
@@ -71,9 +71,13 @@ class MetaLoader_rs(object):
 
         iter_order = []
         for n, l in name2loader.items():
-            iter_order.extend([name2index[n]]*len(l))
+            iter_order.extend([name2index[n]] * len(l))
 
-        random.shuffle(iter_order)
+        if seed is not None:
+            rng = random.Random(seed)
+            rng.shuffle(iter_order)
+        else:
+            random.shuffle(iter_order)
         iter_order = torch.Tensor(iter_order).to(torch.device("cuda")).to(torch.uint8)
 
         # sync

--- a/InternVideo2/multi_modality/tasks_clip/shared_utils.py
+++ b/InternVideo2/multi_modality/tasks_clip/shared_utils.py
@@ -157,8 +157,10 @@ def setup_model(
                 optimizer.load_state_dict(checkpoint["optimizer"])
                 scheduler.load_state_dict(checkpoint["scheduler"])
                 scaler.load_state_dict(checkpoint["scaler"])
-                start_epoch = checkpoint["epoch"] + 1
                 global_step = checkpoint["global_step"]
+                start_epoch = checkpoint["epoch"]
+                if num_steps_per_epoch > 0 and global_step % num_steps_per_epoch == 0:
+                    start_epoch += 1
 
             msg = model_without_ddp.load_state_dict(state_dict, strict=False)
             logger.info(msg)


### PR DESCRIPTION
## Summary
- add RNG helpers and store state in checkpoints
- restore RNG state when resuming
- allow deterministic dataloader ordering
- correct epoch computation when resuming

## Testing
- `python -m py_compile InternVideo2/multi_modality/tasks_clip/pretrain.py InternVideo2/multi_modality/dataset/dataloader.py InternVideo2/multi_modality/tasks_clip/shared_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686422d07bd8832f88fa28f9211e324a