### PR TITLE
Improve resumable training checkpoint logic

### DIFF
--- a/InternVideo2/multi_modality/dataset/dataloader.py
+++ b/InternVideo2/multi_modality/dataset/dataloader.py
@@ -57,8 +57,8 @@ class MetaLoader(object):
 
 
 class MetaLoader_rs(object):
-    """ wraps multiple data loader """
-    def __init__(self, name2loader, skip_num=0):
+    """Wraps multiple data loaders with optional deterministic ordering."""
+    def __init__(self, name2loader, skip_num=0, seed=None):
         """Iterates over multiple dataloaders, it ensures all processes
         work on data from the same dataloader. This loader will end when
         the shorter dataloader raises StopIteration exception.
@@ -71,9 +71,13 @@ class MetaLoader_rs(object):
 
         iter_order = []
         for n, l in name2loader.items():
-            iter_order.extend([name2index[n]]*len(l))
+            iter_order.extend([name2index[n]] * len(l))
 
-        random.shuffle(iter_order)
+        if seed is not None:
+            rng = random.Random(seed)
+            rng.shuffle(iter_order)
+        else:
+            random.shuffle(iter_order)
         iter_order = torch.Tensor(iter_order).to(torch.device("cuda")).to(torch.uint8)
 
         # sync

--- a/InternVideo2/multi_modality/tasks_clip/shared_utils.py
+++ b/InternVideo2/multi_modality/tasks_clip/shared_utils.py
@@ -82,24 +82,26 @@ def setup_model(
         model_best = join(config.output_dir, "ckpt_best.pth")
 
         large_step_num = -1
-        large_num = -1
-        for p in os.listdir(config.output_dir):
-            if 'ckpt_iter' in p:
-                num = p.split('_iter')[1].split('.')[0]
-                if str.isnumeric(num):
-                    if int(num) > large_step_num:
-                        large_step_num = int(num)
-            elif 'ckpt_' in p:
-                num = p.split('_')[1].split('.')[0]
-                if str.isnumeric(num):
-                    if int(num) > large_num:
-                        large_num = int(num)
+        large_epoch_num = -1
+        for fname in os.listdir(config.output_dir):
+            if fname.startswith("ckpt_iter") and fname.endswith(".pth"):
+                step_str = fname[len("ckpt_iter") : -4]
+                if step_str.isdigit():
+                    step_num = int(step_str)
+                    large_step_num = max(large_step_num, step_num)
+            elif fname.startswith("ckpt_") and fname.endswith(".pth"):
+                epoch_str = fname[len("ckpt_") : -4]
+                if epoch_str.isdigit():
+                    epoch_num = int(epoch_str)
+                    large_epoch_num = max(large_epoch_num, epoch_num)
+
         if large_step_num != -1:
             logger.info(f"Load the latest step: {large_step_num}")
-            model_latest = join(config.output_dir, f"ckpt_iter{large_step_num:02d}.pth")
-        if large_num != -1 and (large_num + 1) * num_steps_per_epoch > large_step_num:
-            logger.info(f"Load the latest epoch: {large_num}")
-            model_latest = join(config.output_dir, f"ckpt_{large_num:02d}.pth")
+            model_latest = join(config.output_dir, f"ckpt_iter{large_step_num:07d}.pth")
+
+        if large_epoch_num != -1 and (large_epoch_num + 1) * num_steps_per_epoch > large_step_num:
+            logger.info(f"Load the latest epoch: {large_epoch_num}")
+            model_latest = join(config.output_dir, f"ckpt_{large_epoch_num:02d}.pth")
 
         if hasattr(config, "deepspeed") and config.deepspeed.enable:
             if osp.isdir(model_latest):
@@ -157,11 +159,28 @@ def setup_model(
                 optimizer.load_state_dict(checkpoint["optimizer"])
                 scheduler.load_state_dict(checkpoint["scheduler"])
                 scaler.load_state_dict(checkpoint["scaler"])
-                start_epoch = checkpoint["epoch"] + 1
                 global_step = checkpoint["global_step"]
+                start_epoch = checkpoint["epoch"]
+                if num_steps_per_epoch > 0 and global_step % num_steps_per_epoch == 0:
+                    start_epoch += 1
 
             msg = model_without_ddp.load_state_dict(state_dict, strict=False)
             logger.info(msg)
+            # Handle optional streaming student checkpoint
+            if isinstance(checkpoint, dict):
+                student_key = None
+                if "streaming_student" in checkpoint:
+                    student_key = "streaming_student"
+                elif "streaming_vision_encoder" in checkpoint:
+                    student_key = "streaming_vision_encoder"
+                if student_key is not None:
+                    try:
+                        model_without_ddp.streaming_vision_encoder.load_state_dict(
+                            checkpoint[student_key]
+                        )
+                        logger.info("Loaded streaming student model from checkpoint")
+                    except Exception as e:
+                        logger.warning(f"Failed to load streaming student model: {e}")
             logger.info(f"Loaded checkpoint from {config.pretrained_path}")
         else:
             logger.warning("No pretrained checkpoint provided, training from scratch")


### PR DESCRIPTION
## Summary
- fix checkpoint auto-resume detection to handle `ckpt_iter` files with correct numbering
- attempt to load streaming student weights when present in checkpoint

## Testing
- `python -m py_compile InternVideo2/multi_modality/tasks_clip/pretrain.py InternVideo2/multi_modality/dataset/dataloader.py InternVideo2/multi_modality/tasks_clip/shared_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686422d07bd8832f88fa28f9211e324a