### PR TITLE
Remove verbose frozen parameter logs

### DIFF
--- a/InternVideo2/multi_modality/tasks_clip/pretrain.py
+++ b/InternVideo2/multi_modality/tasks_clip/pretrain.py
@@ -308,15 +308,6 @@ def train(
     model_without_ddp = model.module if config.distributed else model
     model.train()
 
-    logger.info('-'*20)
-
-    # Sanity check for which params are unfrozen
-    for name, param in model_without_ddp.named_parameters():
-        if param.requires_grad:
-            logger.info(f"Unfrozen Parameter: {name}")
-
-    logger.info('-'*20)
-
     try:
         inference_transform = model_without_ddp.transform
         IMG_SIZE = model_without_ddp.config.model.vision_encoder.img_size
@@ -756,7 +747,6 @@ def main(config):
             }
             for k in list(state_dict.keys()):
                 if k in param_grad_dict.keys() and not param_grad_dict[k]:
-                    logger.info(f"Not saving {k}")
                     del state_dict[k]
 
             save_obj = {

--- a/InternVideo2/multi_modality/tasks_clip/retrieval.py
+++ b/InternVideo2/multi_modality/tasks_clip/retrieval.py
@@ -192,7 +192,6 @@ def main(config):
                 for k in list(state_dict.keys()):
                     if k in param_grad_dict.keys() and not param_grad_dict[k]:
                         # delete parameters that do not require gradient
-                        logger.info(f"Not saving {k}")
                         del state_dict[k]
 
                 save_obj = {

--- a/InternVideo2/multi_modality/tasks_clip/retrieval_mc.py
+++ b/InternVideo2/multi_modality/tasks_clip/retrieval_mc.py
@@ -300,7 +300,6 @@ def main(config):
                 for k in list(state_dict.keys()):
                     if k in param_grad_dict.keys() and not param_grad_dict[k]:
                         # delete parameters that do not require gradient
-                        logger.info(f"Not saving {k}")
                         del state_dict[k]
 
                 save_obj = {

--- a/InternVideo2/multi_modality/tasks_clip/retrieval_mc2.py
+++ b/InternVideo2/multi_modality/tasks_clip/retrieval_mc2.py
@@ -304,7 +304,6 @@ def main(config):
                 for k in list(state_dict.keys()):
                     if k in param_grad_dict.keys() and not param_grad_dict[k]:
                         # delete parameters that do not require gradient
-                        logger.info(f"Not saving {k}")
                         del state_dict[k]
 
                 save_obj = {


### PR DESCRIPTION
## Summary
- stop logging each unfrozen/frozen parameter during training and checkpointing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6865772b6a00832f8efd7f9b38629fbc