### PR TITLE
Refactor resume logic for pretraining

### DIFF
--- a/InternVideo2/multi_modality/tasks_clip/pretrain.py
+++ b/InternVideo2/multi_modality/tasks_clip/pretrain.py
@@ -694,13 +694,6 @@ def main(config):
         num_steps_per_epoch=num_steps_per_epoch,
     )
 
-    # restore RNG state from checkpoint if available
-    if config.resume and os.path.isfile(config.pretrained_path):
-        try:
-            ckpt = torch.load(config.pretrained_path, map_location="cpu")
-            set_rng_state(ckpt.get("rng_state"))
-        except Exception as e:
-            logger.warning(f"Failed to load RNG state from checkpoint: {e}")
     if is_main_process() and config.wandb.enable:
         wandb.watch(model)
 


### PR DESCRIPTION
## Summary
- remove auto resume logic from shared utils and implement new checkpoint loading
- clean up RNG restoration

## Testing
- `pytest -q mamba/tests` *(fails: ModuleNotFoundError: No module named 'einops')*

------
https://chatgpt.com/codex/tasks/task_e_6865ef1e0dfc832f8404bf556ca14b83