### PR TITLE
Add FiLM gating for Cross-Mamba

### DIFF
--- a/InternVideo2/multi_modality/models/backbones/internvideo2/video_mamba_block.py
+++ b/InternVideo2/multi_modality/models/backbones/internvideo2/video_mamba_block.py
@@ -1,6 +1,7 @@
 import torch
 from torch import nn
 from mamba_ssm.modules.mamba2 import Mamba2
+import torch.nn.functional as F
 
 class VideoMambaBlock(nn.Module):
     """State-space block for streaming video features using Mamba.
@@ -57,3 +58,22 @@ class VideoMambaBlock(nn.Module):
         out = out * torch.sigmoid(self.out_gate(out))
         clip_emb = self.proj(out)
         return clip_emb, (conv_state, ssm_state)
+
+
+class CrossMambaFiLM(VideoMambaBlock):
+    """VideoMambaBlock with FiLM-style text conditioning."""
+
+    def __init__(self, in_dim, hidden_dim, clip_dim, num_heads=4, d_state=64, d_conv=4):
+        super().__init__(in_dim, hidden_dim, clip_dim, num_heads, d_state, d_conv)
+        self.film = nn.Linear(clip_dim, 2 * in_dim, bias=True)
+
+    @torch.no_grad()
+    def prepare_prompt(self, prompt_vec):
+        """Prepare FiLM parameters from text embedding."""
+        gamma, beta = self.film(prompt_vec).chunk(2, dim=-1)
+        return gamma.sigmoid(), beta
+
+    def forward(self, frame_feat, state, gamma=None, beta=None):
+        if gamma is not None and beta is not None:
+            frame_feat = gamma * frame_feat + beta
+        return super().forward(frame_feat, state)

--- a/InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py
+++ b/InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py
@@ -69,7 +69,7 @@ model = dict(
     ),
     streaming_vision_encoder = dict(
         vit_lite_embed_dim = 768,
-        rnn_type = 'mamba',
+        rnn_type = 'cross_mamba_film',
         rnn_hidden_size = 1024,
         rnn_num_layers = 3,
         rnn_dropout = 0.0,

--- a/run_stream.py
+++ b/run_stream.py
@@ -1,0 +1,46 @@
+import torch
+import torch.nn.functional as F
+from InternVideo2.multi_modality.models.backbones.internvideo2.internvideo2_clip_recycle import StreamingInternVideo2Student
+from InternVideo2.multi_modality.models.backbones.internvideo2.video_mamba_block import CrossMambaFiLM
+
+
+def dummy_text_encode(prompt: str, dim: int):
+    # Placeholder text encoder returning random features
+    torch.manual_seed(len(prompt))
+    return torch.randn(1, dim)
+
+
+def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    student_config = {
+        "vit_lite_model_name": "vit_b16",
+        "vit_lite_proj_dim": 512,
+        "vit_lite_embed_dim": 768,
+        "rnn_type": 'cross_mamba_film',
+        "rnn_hidden_size": 512,
+        "rnn_num_layers": 1,
+        "rnn_dropout": 0.0,
+        "fc_hidden_layers": [256],
+        "teacher_clip_embed_dim": 768,
+    }
+
+    model = StreamingInternVideo2Student(**student_config).to(device)
+    model.eval()
+
+    # Prepare FiLM params from text prompt
+    prompt_vec = dummy_text_encode("a person riding a horse", student_config["teacher_clip_embed_dim"]).to(device)
+    gamma, beta = model.rnn.prepare_prompt(prompt_vec)
+
+    hidden = model.init_hidden(batch_size=1, device=device)
+
+    for step in range(3):
+        frame = torch.randn(1, 3, 224, 224).to(device)
+        with torch.no_grad():
+            out, hidden = model(frame, hidden, gamma, beta)
+        score = F.cosine_similarity(out, prompt_vec, dim=-1)
+        print(f"step {step} score {score.item():.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `CrossMambaFiLM` block with FiLM modulation
- support new `rnn_type` `cross_mamba_film` in `StreamingInternVideo2Student`
- provide small example `run_stream.py` showing usage
- integrate CrossMambaFiLM into training script
- update B14 pretraining config to use new rnn type

## Testing
- `python -m py_compile InternVideo2/multi_modality/models/backbones/internvideo2/video_mamba_block.py`
- `python -m py_compile InternVideo2/multi_modality/tasks_clip/pretrain.py`
- `python -m py_compile InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py`
- `python -m py_compile run_stream.py`
- `pip install torch==2.2.2 --quiet` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686ae7716fc0832f9ef9f7719add7987