### PR TITLE
Enable mid-epoch MobileCLIP vision unfreeze

### DIFF
--- a/InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py
+++ b/InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py
@@ -84,6 +84,7 @@ model = dict(
     use_streaming_vision_align = False,
     freeze_vision=True,
     freeze_mobileclip_vision=True, # Freeze the MobileCLIP vision encoder
+    unfreeze_mobileclip_ratio=0.5,
     open_vision_clip_projector=False,
     freeze_mobileclip_text=True,
     open_text_projection=False,

--- a/InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py
+++ b/InternVideo2/multi_modality/scripts/pretraining/clip/B14/config.py
@@ -108,7 +108,7 @@ optimizer = dict(
     weight_decay=0.01,
     max_grad_norm=0.7,  # requires a positive float, use -1 to disable
     # use a different lr for some modules, e.g., larger lr for new modules
-    different_lr=dict(enable=True, module_names=["streaming_vision_encoder.vit_lite"], lr=1e-5),
+    different_lr=dict(enable=True, module_names=["streaming_vision_encoder.vit_lite"], lr=2e-6),
 )
 
 scheduler = dict(sched="cosine", epochs=2, min_lr_multi=0.01, warmup_epochs=0.1)

--- a/InternVideo2/multi_modality/tasks_clip/pretrain.py
+++ b/InternVideo2/multi_modality/tasks_clip/pretrain.py
@@ -32,6 +32,11 @@ from utils.basic_utils import MetricLogger, SmoothedValue, setup_seed
 from utils.config_utils import setup_main
 from utils.distributed import get_rank, is_main_process
 from utils.logger import log_dict_to_wandb, setup_wandb
+from utils.optimizer import (
+    add_different_lr,
+    create_optimizer_params_group,
+    extend_optimizer_with_param_groups,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +64,39 @@ def set_rng_state(state):
             torch.cuda.set_rng_state_all(state["cuda_state"])
     except Exception as e:
         logger.warning(f"Failed to restore RNG state: {e}")
+
+
+def unfreeze_mobileclip_vision(model, optimizer, scheduler, config):
+    """Unfreeze MobileCLIP vision encoder and add its params to the optimizer."""
+    logger.info("Unfreezing MobileCLIP vision encoder parameters")
+
+    submodule = model.streaming_vision_encoder.vit_lite
+    for p in submodule.parameters():
+        p.requires_grad = True
+
+    weight_decay = config.optimizer.weight_decay
+    named_param_tuples = []
+    for name, param in submodule.named_parameters():
+        full_name = f"streaming_vision_encoder.vit_lite.{name}"
+        if len(param.shape) == 1 or full_name.endswith(".bias"):
+            wd = 0
+        else:
+            wd = weight_decay
+        named_param_tuples.append([full_name, param, wd])
+
+    if hasattr(config.optimizer, "different_lr") and config.optimizer.different_lr.enable:
+        diff_names = config.optimizer.different_lr.module_names
+        diff_lr = config.optimizer.different_lr.lr
+    else:
+        diff_names = []
+        diff_lr = None
+
+    named_param_tuples = add_different_lr(named_param_tuples, diff_names, diff_lr, config.optimizer.lr)
+    param_groups = create_optimizer_params_group(named_param_tuples, config.optimizer.lr)
+    extend_optimizer_with_param_groups(optimizer, scheduler, param_groups)
+
+    # Mark as unfrozen so we don't unfreeze again
+    config.model.freeze_mobileclip_vision = False
 
 def save_debug_step_data(output_dir, global_step, frame_idx,
                          new_frame_input, # Input to streaming_vision_encoder
@@ -359,6 +397,11 @@ def train(
 
     num_batches_train = len(train_loader_agg)
     logger.info(f"Training loader set up, {num_batches_train} batches.")
+    unfreeze_ratio = getattr(config.model, "unfreeze_mobileclip_ratio", None)
+    if unfreeze_ratio is not None:
+        unfreeze_step = int(num_batches_train * unfreeze_ratio)
+    else:
+        unfreeze_step = None
 
     progress_bar = tqdm(
         train_loader_agg,
@@ -398,6 +441,16 @@ def train(
         return torch.nn.functional.cross_entropy(logits, targets)
 
     for i, data_pair in enumerate(progress_bar):
+        if (
+            unfreeze_step is not None
+            and epoch == 0
+            and i >= unfreeze_step
+            and config.model.freeze_mobileclip_vision
+        ):
+            unfreeze_mobileclip_vision(
+                model_without_ddp, optimizer, scheduler, config
+            )
+
         media_type_orig_data, (image, text, idx) = data_pair # Renamed for clarity
 
         image = image.to(device, non_blocking=True)

--- a/InternVideo2/multi_modality/utils/optimizer.py
+++ b/InternVideo2/multi_modality/utils/optimizer.py
@@ -146,3 +146,28 @@ def create_optimizer(args, model, filter_bias_and_bn=True, return_group=False):
         assert False and "Invalid optimizer"
         raise ValueError
     return optimizer
+
+
+def extend_optimizer_with_param_groups(optimizer, scheduler, param_groups):
+    """Add parameter groups to an existing optimizer and update scheduler.
+
+    Args:
+        optimizer (Optimizer): The optimizer to extend.
+        scheduler (torch.optim.lr_scheduler._LRScheduler or None): Scheduler tied
+            to the optimizer. ``base_lrs`` will be extended if provided.
+        param_groups (List[dict]): Parameter groups returned by
+            :func:`create_optimizer_params_group`.
+    """
+
+    for group in param_groups:
+        add_group = {k: group[k] for k in ["params", "lr", "weight_decay"]}
+        optimizer.add_param_group(add_group)
+        # attach custom info for logging
+        optimizer.param_groups[-1]["name"] = group.get("name")
+        optimizer.param_groups[-1]["different_lr"] = group.get("different_lr", False)
+
+        if scheduler is not None and hasattr(scheduler, "base_lrs"):
+            scheduler.base_lrs.append(group["lr"])
+            if hasattr(scheduler, "_last_lr"):
+                scheduler._last_lr.append(group["lr"])
+


### PR DESCRIPTION
## Summary
- add helper to extend optimizers with new parameter groups
- allow unfreezing MobileCLIP vision encoder midway through epoch using `unfreeze_mobileclip_ratio`
- update B14 config to define new ratio flag
- fix logic to toggle `freeze_mobileclip_vision` when unfreezing
- handle optional ratio so other configs remain unaffected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mamba_ssm')*

------
https://chatgpt.com/codex/tasks/task_e_686b1dc00648832f8653e9b00c195b68