### PR TITLE
Switch to MambaSPFS

### DIFF
--- a/InternVideo2/multi_modality/models/backbones/internvideo2/video_mamba_block.py
+++ b/InternVideo2/multi_modality/models/backbones/internvideo2/video_mamba_block.py
@@ -83,8 +83,8 @@ class CrossMambaFiLM(VideoMambaBlock):
         return super().forward(frame_feat, state)
 
 
-class CrossMambaSPFS(CrossMambaFiLM):
-    """CrossMambaFiLM with a low-rank feature predictor for SPFS."""
+class MambaSPFS(VideoMambaBlock):
+    """VideoMambaBlock with a low-rank feature predictor for SPFS."""
 
     def __init__(self, *args, pred_rank=32, **kw):
         super().__init__(*args, **kw)
@@ -95,8 +95,8 @@ class CrossMambaSPFS(CrossMambaFiLM):
         self.logvar = nn.Linear(self.ssm.d_model, 1)
         self.last_hidden = None
 
-    def forward(self, frame_feat, state, gamma=None, beta=None, tau=None):
-        clip_emb, state = super().forward(frame_feat, state, gamma, beta, tau)
+    def forward(self, frame_feat, state):
+        clip_emb, state = super().forward(frame_feat, state)
         # Store hidden representation for next-step prediction
         self.last_hidden = self._hidden
         return clip_emb, state

--- a/InternVideo2/multi_modality/scripts/spfs/clip/B14/config.py
+++ b/InternVideo2/multi_modality/scripts/spfs/clip/B14/config.py
@@ -54,7 +54,7 @@ model = dict(
     ),
     streaming_vision_encoder=dict(
         vit_lite_embed_dim=768,
-        rnn_type='stream_mamba',
+        rnn_type='mamba_spfs',
         rnn_hidden_size=1024,
         rnn_num_layers=3,
         rnn_dropout=0.0,


### PR DESCRIPTION
## Summary
- implement `MambaSPFS` block without FiLM conditioning
- use `MambaSPFS` in `StreamMamba`
- update SPFS config to `mamba_spfs`

## Testing
- `pytest InternVideo2/multi_modality/miscs/test_flops.py::test_flops -q` *(fails: ModuleNotFoundError: No module named 'models')*

------
https://chatgpt.com/codex/tasks/task_e_6875f8b944e8832fbfe264d42ceb6c21